### PR TITLE
fix modal

### DIFF
--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -1,9 +1,9 @@
 @csrf
 <div class="md-form">
   <label>タイトル</label>
-  <input type="text" name="title" class="form-control" required value="{{ old('title') }}">
+  <input type="text" name="title" class="form-control" required value="{{ $article->title ?? old('title') }}">
 </div>
 <div class="form-group">
   <label></label>
-  <textarea name="body" required class="form-control" row="16" placeholder="本文">{{ old('body') }}</textarea>
+  <textarea name="body" required class="form-control" row="16" placeholder="本文">{{ $article->body ?? old('title') }}</textarea>
 </div>

--- a/resources/views/articles/index.blade.php
+++ b/resources/views/articles/index.blade.php
@@ -33,7 +33,7 @@
                   <i class="fas fa-pen mr-1"></i>記事を更新する
                 </a>
                 <div class="dropdown-divider"></div>
-                <a class="dropdown-item text-danger" data-toggle="modal" data-target="#modal-delete{{ $article->id }}">
+                <a class="dropdown-item text-danger" data-toggle="modal" data-target="#modal-delete-{{ $article->id }}">
                   <i class="fas fa-trash-alt mr-1"></i>記事を削除する
                 </a>
               </div>


### PR DESCRIPTION
# モーダルウインドウと編集画面の修正

## WHAT

- 編集画面に値が引き継がれるように修正
    Null演算子 `a ?? b` を使い、データがあるときにbが働くように実装
- モーダルウインドウの『削除』を押したときに何も起こらなかったので修正
