### PR TITLE
Add policy

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -8,6 +8,11 @@ use Illuminate\Http\Request;
 
 class ArticleController extends Controller
 {
+    public function __construct()
+    {
+        $this->authorizeResource(Article::class, 'article');
+    }
+    
     public function index()
     {
         $articles = Article::all()->sortByDesc('created_at');

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -16,7 +16,7 @@ class ArticlePolicy
      * @param  \App\User  $user
      * @return mixed
      */
-    public function viewAny(User $user)
+    public function viewAny(?User $user)
     {
         return true;
     }
@@ -28,7 +28,7 @@ class ArticlePolicy
      * @param  \App\Article  $article
      * @return mixed
      */
-    public function view(User $user, Article $article)
+    public function view(?User $user, Article $article)
     {
         return true;
     }

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Policies;
+
+use App\Article;
+use App\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ArticlePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any articles.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the article.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Article  $article
+     * @return mixed
+     */
+    public function view(User $user, Article $article)
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create articles.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the article.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Article  $article
+     * @return mixed
+     */
+    public function update(User $user, Article $article)
+    {
+        return $user->id === $article->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the article.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Article  $article
+     * @return mixed
+     */
+    public function delete(User $user, Article $article)
+    {
+        return $user->id === $article->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the article.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Article  $article
+     * @return mixed
+     */
+    public function restore(User $user, Article $article)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the article.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Article  $article
+     * @return mixed
+     */
+    public function forceDelete(User $user, Article $article)
+    {
+        //
+    }
+}

--- a/resources/views/nav.blade.php
+++ b/resources/views/nav.blade.php
@@ -6,7 +6,7 @@
 
     @guest
     <li class="nav-item">
-      <a class="nav-link" href="">ユーザー登録</a>
+      <a class="nav-link" href="{{ route('register') }}">ユーザー登録</a>
     </li>
     @endguest
 


### PR DESCRIPTION
# ポリシーの追加

## WHAT

- `/articles/1/edit` など、URLを直接指定することで別ユーザーが別ユーザーの記事を編集や削除することができてしまっていた問題の解決
- ポリシーを作成し、記事モデルに対して特定のユーザーのアクションを認可する
- ポリシーの `view` と `viewany` の記述をnullableな型に変更し、ユーザーがログインしているかどうかを求めないようにする
- コントローラにコンストラクタを追加する
