### PR TITLE
fix js

### DIFF
--- a/resources/js/components/ArticleLike.vue
+++ b/resources/js/components/ArticleLike.vue
@@ -26,13 +26,13 @@
         type: Number,
         default: 0,
       },
-    },
-    authotized: {
-      type: Boolean,
-      default: false,
-    },
-    endpoint: {
-      type: String,
+      authorized: {
+        type: Boolean,
+        default: false,
+      },
+      endpoint: {
+        type: String,
+      },
     },
     data() {
       return {


### PR DESCRIPTION
# いいね非同期通信の修正

## WHAT

- 閉じカッコの位置を間違えていたためログイン中と判断されずに警告が出ていた
