### PR TITLE
Add tag

### DIFF
--- a/app/Article.php
+++ b/app/Article.php
@@ -48,4 +48,10 @@ class Article extends Model
         // countメソッドでコレクションの要素数を数える
         return $this->likes->count();
     }
+
+    // tagテーブルへの多対多のリレーションを定義
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany('App\Tag')->withTimestamps();
+    }
 }

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -31,12 +31,11 @@ class ArticleController extends Controller
         $article->fill($request->all());
         $article->user_id = $request->user()->id;
         $article->save();
-        return redirect()->route('articles.index');
         // 渡されたクロージャの第一引数にはコレクションの値
             // 第二引数にはコレクションのキーが入っている
         // 繰り返し処理の1回目では、例えば['USA', 'France']であれば
         //     第一引数はUSA、第二引数には0（2回目の繰り返しでは1）
-        $request->tag->each(function ($tagName) use ($article) {
+        $request->tags->each(function ($tagName) use ($article) {
             // すでにtagsテーブルに存在するかそうでないかを判断
             $tag = Tag::firstOrCreate(['name' => $tagName]);
             $article->tags()->attach($tag);
@@ -46,7 +45,16 @@ class ArticleController extends Controller
 
     public function edit(Article $article)
     {
-        return view('articles.edit', ['article' => $article]);
+        // タグ名に対してtextというキーが付いている必要があるため
+        //     mapメソッドで連想配列にする
+        $tagNames = $article->tags->map(function ($tag) {
+            return ['text' => $tag->name];
+        });
+        return view('articles.edit', [
+            'article' => $article,
+            // ブレードに$tagNamesという変数で渡す
+            'tagNames' => $tagNames,
+        ]);
     }
 
     public function update(ArticleRequest $request, Article $article)

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Article;
+use App\Tag;
 use App\Http\Requests\ArticleRequest;
 use Illuminate\Http\Request;
 
@@ -30,6 +31,16 @@ class ArticleController extends Controller
         $article->fill($request->all());
         $article->user_id = $request->user()->id;
         $article->save();
+        return redirect()->route('articles.index');
+        // 渡されたクロージャの第一引数にはコレクションの値
+            // 第二引数にはコレクションのキーが入っている
+        // 繰り返し処理の1回目では、例えば['USA', 'France']であれば
+        //     第一引数はUSA、第二引数には0（2回目の繰り返しでは1）
+        $request->tag->each(function ($tagName) use ($article) {
+            // すでにtagsテーブルに存在するかそうでないかを判断
+            $tag = Tag::firstOrCreate(['name' => $tagName]);
+            $article->tags()->attach($tag);
+        });
         return redirect()->route('articles.index');
     }
 

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -23,7 +23,13 @@ class ArticleController extends Controller
 
     public function create()
     {
-        return view('articles.create');
+        $allTagNames = Tag::all()->map(function ($tag) {
+            return ['text' => $tag->name];
+        });
+
+        return view('articles.create', [
+            'allTagNames' => $allTagNames,
+        ]);
     }
 
     public function store(ArticleRequest $request, Article $article)
@@ -50,16 +56,30 @@ class ArticleController extends Controller
         $tagNames = $article->tags->map(function ($tag) {
             return ['text' => $tag->name];
         });
+
+        // 自動補完機能のため
+        $allTagNames = Tag::all()->map(function ($tag) {
+            return ['text' => $tag->name];
+        });
+
         return view('articles.edit', [
             'article' => $article,
             // ブレードに$tagNamesという変数で渡す
             'tagNames' => $tagNames,
+            'allTagNames' => $allTagNames,
         ]);
     }
 
     public function update(ArticleRequest $request, Article $article)
     {
         $article->fill($request->all())->save();
+
+        $article->tags()->detach();
+        $request->tags->each(function ($tagName) use ($article) {
+            $tag = Tag::firstOrCreate(['name' => $tagName]);
+            $article->tags()->attach($tag);
+        });
+
         return redirect()->route('articles.index');
     }
 

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Tag;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    // ルーティングに定義したURLの{name}の部分に入った文字列が渡る
+    public function show(string $name)
+    {
+        // whereを使って$nameと一致するタグ名を持つタグモデルをコレクションで取得
+        $tag = Tag::where('name', $name)->first();
+
+        // viewメソッドを使ってタグ別一覧画面のBladeを表示
+            // タグモデルの入った$tagを渡す
+        return view('tags.show', ['tag' => $tag]);
+    }
+}

--- a/app/Http/Requests/ArticleRequest.php
+++ b/app/Http/Requests/ArticleRequest.php
@@ -26,6 +26,8 @@ class ArticleRequest extends FormRequest
         return [
             'title' => 'required|max:50',
             'body' => 'required|max:500',
+            // json形式かどうかのバリデーション。半角スペースが無いことをチェックする正規表現
+            'tags' => 'json|regex:/^(?!.*\s).+$/u',
         ];
     }
 
@@ -34,6 +36,21 @@ class ArticleRequest extends FormRequest
         return [
             'title' => 'タイトル',
             'body' => '本文',
+            'tags' => 'タグ',
         ];
+    }
+
+    // フォームリクエストのバリデーションが成功した後に自動的に呼ばれるメソッド
+    public function passedValidation()
+    {
+        // json_decode関数を使ってJSON形式の文字列であるタグ情報を連想配列に変換
+        // コレクションメソッドを使うためにコレクション形式に変換
+        $this->tags = collect(json_decode($this->tags))
+        // コレクションの要素が6個以上あったとしても最初の5個だけが残る
+        ->slice(0, 5)
+        // 引数に関数を渡す
+        ->map(function ($requestTag) {
+            return $requestTag->text;
+        });
     }
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    //
+}

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -6,5 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Tag extends Model
 {
-    //
+    protected $fillable = [
+        'name',
+    ];
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -9,4 +9,10 @@ class Tag extends Model
     protected $fillable = [
         'name',
     ];
+
+    // タグをハッシュタグ風に表示するアクセサ
+    public function getHashtagAttribute(): string
+    {
+        return '#' .$this->name;
+    }
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Tag extends Model
 {
@@ -14,5 +15,11 @@ class Tag extends Model
     public function getHashtagAttribute(): string
     {
         return '#' .$this->name;
+    }
+
+    // タグモデルと記事モデルのリレーション（多対多）を定義
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany('App\Article')->withTimestamps();
     }
 }

--- a/database/migrations/2020_04_04_141323_create_tags_table.php
+++ b/database/migrations/2020_04_04_141323_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/database/migrations/2020_04_04_141532_create_article_tag_table.php
+++ b/database/migrations/2020_04_04_141532_create_article_tag_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateArticleTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_tag', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('article_id');
+            $table->foreign('article_id')
+                ->references('id')
+                ->on('articles')
+                ->onDelete('cascade');
+            $table->bigInteger('tag_id');
+            $table->foreign('tag_id')
+                ->references('id')
+                ->on('tags')
+                ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_tag');
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -951,6 +951,15 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@johmun/vue-tags-input": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@johmun/vue-tags-input/-/vue-tags-input-2.1.0.tgz",
+            "integrity": "sha512-Fdwfss/TqCqMJbGAkmlzKbcG/ia1MstYjhqPBj+zG7h/166tIcE1TIftUxhT9LZ+RWjRSG0EFA1UyaHQSr3k3Q==",
+            "dev": true,
+            "requires": {
+                "vue": "^2.6.10"
+            }
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
+        "@johmun/vue-tags-input": "^2.1.0",
         "axios": "^0.19",
         "cross-env": "^5.1",
         "laravel-mix": "^4.0.7",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,10 +3,12 @@
 import './bootstrap'
 import Vue from 'vue'
 import ArticleLike from './components/ArticleLike'
+import ArticleTagsInput from './components/ArticleTagsInput'
 
 const app = new Vue({
   el: '#app',
   components: {
     ArticleLike,
+    ArticleTagsInput,
   }
 })

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -63,4 +63,7 @@ export default {
     border-radius: 0px;
     font-size: 13px;
   }
+  .vue-tags-input .ti-tag::before {
+    content: "#";
+  }
 </style>

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <vue-tags-input
+      v-model="tag"
+      :tags="tags"
+      :autocomplete-items="filteredItems"
+      @tags-changed="newTags => tags = newTags"
+    />
+  </div>
+</template>
+
+<script>
+import VueTagsInput from '@johmun/vue-tags-input';
+
+export default {
+  components: {
+    VueTagsInput,
+  },
+  data() {
+    return {
+      tag: '',
+      tags: [],
+      autocompleteItems: [{
+        text: 'Spain',
+      }, {
+        text: 'France',
+      }, {
+        text: 'USA',
+      }, {
+        text: 'Germany',
+      }, {
+        text: 'China',
+      }],
+    };
+  },
+  computed: {
+    filteredItems() {
+      return this.autocompleteItems.filter(i => {
+        return i.text.toLowerCase().indexOf(this.tag.toLowerCase()) !== -1;
+      });
+    },
+  },
+};
+</script>
+<style lang="css" scoped>
+  .vue-tags-input .ti-tag {
+    background: trancsparent;
+    border: 1px solid #747373;
+    color: #747373;
+    margin-right: 4px;
+    border-radius: 0px;
+    font-size: 13px;
+  }
+</style>

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -42,7 +42,7 @@ export default {
   },
 };
 </script>
-<style lang="css" scoped>
+<style lang="css">
   .vue-tags-input .ti-tag {
     background: trancsparent;
     border: 1px solid #747373;

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -22,10 +22,18 @@ export default {
   components: {
     VueTagsInput,
   },
+  props: {
+    // Bladeから渡されたタグ情報を受け取る
+    initialTags: {
+      type: Array,
+      default: [],
+    },
+  },
   data() {
     return {
       tag: '',
-      tags: [],
+      // initialTagsの値のデータをtagsの初期値としてセット
+      tags: this.initialTags,
       autocompleteItems: [{
         text: 'Spain',
       }, {

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -28,23 +28,16 @@ export default {
       type: Array,
       default: [],
     },
+    autocompleteItems: {
+      type: Array,
+      default: [],
+    },
   },
   data() {
     return {
       tag: '',
       // initialTagsの値のデータをtagsの初期値としてセット
       tags: this.initialTags,
-      autocompleteItems: [{
-        text: 'Spain',
-      }, {
-        text: 'France',
-      }, {
-        text: 'USA',
-      }, {
-        text: 'Germany',
-      }, {
-        text: 'China',
-      }],
     };
   },
   computed: {

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -55,7 +55,7 @@ export default {
 </script>
 <style lang="css">
   .vue-tags-input .ti-tag {
-    background: trancsparent;
+    background: transparent;
     border: 1px solid #747373;
     color: #747373;
     margin-right: 4px;

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -1,8 +1,14 @@
 <template>
   <div>
+    <input
+      type="hidden"
+      name="tags"
+      :value="tagsJson"
+    >
     <vue-tags-input
       v-model="tag"
       :tags="tags"
+      placeholder="タグを5個まで入力できます"
       :autocomplete-items="filteredItems"
       @tags-changed="newTags => tags = newTags"
     />
@@ -38,6 +44,11 @@ export default {
       return this.autocompleteItems.filter(i => {
         return i.text.toLowerCase().indexOf(this.tag.toLowerCase()) !== -1;
       });
+    },
+    // 算出プロパティ
+    // データ tags をJSON形式の文字列にして返す
+    tagsJson() {
+      return JSON.stringify(this.tags)
     },
   },
 };

--- a/resources/views/articles/card.blade.php
+++ b/resources/views/articles/card.blade.php
@@ -79,5 +79,21 @@
         </article-like>
       </div>
     </div>
+    @foreach($article->tags as $tag)
+      {{-- $loop関数は@foreachの中で使える変数 --}}
+      {{-- 最初の一回だけ行われる処理 --}}
+      @if($loop->first)
+        <div class="card-body pt-0 pd-4 pl-3">
+          <div class="card-text line-height">
+      @endif
+            <a href="" class="border p-1 mr-1 mt-1 text-muted">
+              {{ $tag->name }}
+            </a>
+      {{-- 最後だけ行われる処理 --}}
+      @if($loop->last)
+          </div>
+        </div>
+      @endif
+    @endforeach
   </div>
 </div>

--- a/resources/views/articles/card.blade.php
+++ b/resources/views/articles/card.blade.php
@@ -89,7 +89,7 @@
         <div class="card-body pt-0 pd-4 pl-3">
           <div class="card-text line-height">
       @endif
-            <a href="" class="border p-1 mr-1 mt-1 text-muted">
+            <a href="{{ route('tags.show', ['name' => $tag->name]) }}" class="border p-1 mr-1 mt-1 text-muted">
               {{ $tag->hashtag }}
             </a>
       {{-- 最後だけ行われる処理 --}}

--- a/resources/views/articles/card.blade.php
+++ b/resources/views/articles/card.blade.php
@@ -7,6 +7,7 @@
     </div>
 
   @if( Auth::id() === $article->user_id )
+    
     <!-- dropdown -->
       <div class="ml-auto card-text">
         <div class="dropdown">
@@ -50,9 +51,11 @@
         </div>
       </div>
       <!-- modal -->
+
     @endif
 
   </div>
+  
   <div class="card-body pt-0">
     <h3 class="h4 card-title">
       <a class="text-dark" href="{{ route('articles.show', ['article' => $article]) }}">

--- a/resources/views/articles/card.blade.php
+++ b/resources/views/articles/card.blade.php
@@ -55,7 +55,7 @@
     @endif
 
   </div>
-  
+
   <div class="card-body pt-0">
     <h3 class="h4 card-title">
       <a class="text-dark" href="{{ route('articles.show', ['article' => $article]) }}">
@@ -90,7 +90,7 @@
           <div class="card-text line-height">
       @endif
             <a href="" class="border p-1 mr-1 mt-1 text-muted">
-              {{ $tag->name }}
+              {{ $tag->hashtag }}
             </a>
       {{-- 最後だけ行われる処理 --}}
       @if($loop->last)

--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -6,7 +6,9 @@
 
 {{-- タグ機能 --}}
 <div class="form-group">
+  {{-- vueのInitialTagsプロパティにタグ情報の入った$tagNamesの値を渡す --}}
   <article-tags-input
+  :initial-tags='@json($tagNames ?? [])'
   >
   </article-tags-input>
 </div>

--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -3,6 +3,14 @@
   <label>タイトル</label>
   <input type="text" name="title" class="form-control" required value="{{ $article->title ?? old('title') }}">
 </div>
+
+{{-- タグ機能 --}}
+<div class="form-group">
+  <article-tags-input
+  >
+  </article-tags-input>
+</div>
+
 <div class="form-group">
   <label></label>
   <textarea name="body" required class="form-control" row="16" placeholder="本文">{{ $article->body ?? old('title') }}</textarea>

--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -8,7 +8,9 @@
 <div class="form-group">
   {{-- vueのInitialTagsプロパティにタグ情報の入った$tagNamesの値を渡す --}}
   <article-tags-input
+  {{-- ?? [] としているのはnullである場合の考慮 --}}
   :initial-tags='@json($tagNames ?? [])'
+  :autocomplete-items='@json($allTagNames ?? [])'
   >
   </article-tags-input>
 </div>

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -1,0 +1,20 @@
+@extends('app')
+
+@section('title', $tag->hashtag)
+
+@section('content')
+  @include('nav')
+  <div class="container">
+    <div class="card mt-3">
+      <div class="card-body">
+        <h2 class="h4 card-title m-0">{{ $tag->hashtag }}</h2>
+        <div class="card-text text-right">
+          {{ $tag->articles->count() }}件
+        </div>
+      </div>
+    </div>
+    @foreach($tag->articles as $article)
+      @include('articles.card')
+    @endforeach
+  </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,5 +12,6 @@ Route::resource('/articles', 'ArticleController')->only(['show']);
 // nameメソッドはルーティングに名前をつける
 Route::prefix('articles')->name('articles.')->group(function () {
   Route::put('/{article}/like', 'ArticleController@like')->name('like')->middleware('auth');
-  ROute::delete('/{article}/like', 'ArticleController@unlike')->name('unlike')->middleware('auth');
+  Route::delete('/{article}/like', 'ArticleController@unlike')->name('unlike')->middleware('auth');
 }); 
+Route::get('/tags/{name}', 'TagController@show')->name('tags.show');


### PR DESCRIPTION
# 記事のタグを実装

## WHAT

- 記事を投稿する、もしくは編集する際にタグを5つまで登録できる
- 編集画面にも登録されたタグが引き継がれる
- タグに無効な入力（例えば `t a g` など）をすると警告メッセージが出る
- タグはCSSとアクセサでハッシュタグ風に表示される
- すでに登録されたタグは投稿時に自動補完される
- タグをクリックすると、該当記事が一覧表示される
