### PR TITLE
User follow

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -19,4 +19,43 @@ class UserController extends Controller
             'user' => $user,
         ]);
     }
+
+    // フォロー
+    // 引数 $user にはURLのnameの部分が渡ってくる
+    public function follow(Request $request, string $name)
+    {
+        // 条件に一致するユーザーモデルをコレクションとして最初の1件を取得
+            // $user にはフォローされる側のユーザーのユーザーモデルが代入される
+        $user = User::where('name', $name)->first();
+
+        if ($user->id === $request->user()->id)
+        {
+            // 自分自身をフォローしようとするとエラーのHTTPステータスコードをレスポンスする
+            return abort('404', 'Cannnot follow yourself.');
+        }
+
+        // followingメソッドは多対多のリレーション（BelongsToManyクラスのインスタンス）が返ることを想定
+        // detachしてからattachしているのは複数回重ねてフォローできないようにするため
+        $request->user()->followings()->detach($user);
+        $request->user()->followings()->attach($user);
+
+        // コントローラで配列や連想配列を返すと、JSON形式に変換されてレスポンスされる
+        // どのユーザーへのフォローが成功したかがわかるようにユーザーの名前を返す
+        return ['name' => $name];
+    }
+
+    // フォロー解除
+    public function unfollow(Request $request, string $name)
+    {
+        $user = User::where('name', $name)->first();
+
+        if ($user->id === $request->user()->id)
+        {
+            return abort('404', 'Cannnot follow yourself.');
+        }
+
+        $request->user()->followings()->detach($user);
+
+        return ['name' => $name];
+    }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -31,7 +31,7 @@ class UserController extends Controller
         if ($user->id === $request->user()->id)
         {
             // 自分自身をフォローしようとするとエラーのHTTPステータスコードをレスポンスする
-            return abort('404', 'Cannnot follow yourself.');
+            return abort('404', 'Cannot follow yourself.');
         }
 
         // followingメソッドは多対多のリレーション（BelongsToManyクラスのインスタンス）が返ることを想定
@@ -51,7 +51,7 @@ class UserController extends Controller
 
         if ($user->id === $request->user()->id)
         {
-            return abort('404', 'Cannnot follow yourself.');
+            return abort('404', 'Cannot follow yourself.');
         }
 
         $request->user()->followings()->detach($user);

--- a/app/User.php
+++ b/app/User.php
@@ -4,8 +4,8 @@ namespace App;
 
 use App\Mail\BareMail;
 use App\Notifications\PasswordResetNotification;
-
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Databese\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -44,5 +44,19 @@ class User extends Authenticatable
     public function sendPasswordResetNotification($token)
     {
         $this->notify(new PasswordResetNotification($token, new BareMail()));
+    }
+
+    // リレーション（多対多）
+    public function followers(): BelongsToMany
+    {
+        return $this->belongsToMany('App\User', 'follows', 'followee_id', 'follower_id')->withTimeStamps();
+    }
+
+    // あるユーザーをフォロー中かどうかを判定するメソッド
+    public function isFollowedBy(?User $user): bool
+    {
+        return $user
+            ? (bool)$this->followers->where('id', $user->id)->count()
+            : false;
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -58,7 +58,7 @@ class User extends Authenticatable
     {
         // リレーション元のusersテーブルのidは、中間テーブルのfollower_idと紐付く
         // リレーション先のusersテーブルのidは、中間テーブルのfollowee_idと紐付く
-        return $this->belongsToMany('App\User', 'follows', 'followee_id', 'follower_id')->withTimestamps();
+        return $this->belongsToMany('App\User', 'follows', 'follower_id', 'followee_id')->withTimestamps();
     }
 
     // あるユーザーをフォロー中かどうかを判定するメソッド
@@ -67,5 +67,17 @@ class User extends Authenticatable
         return $user
             ? (bool)$this->followers->where('id', $user->id)->count()
             : false;
+    }
+
+    // フォロー数を算出するアクセサ
+    public function getCountFollowersAttribute(): int
+    {
+        return $this->followers->count();
+    }
+
+    // フォロワー数を算出するアクセサ
+    public function getCountFollowingsAttribute(): int
+    {
+        return $this->followings->count();
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -5,7 +5,7 @@ namespace App;
 use App\Mail\BareMail;
 use App\Notifications\PasswordResetNotification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Databese\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -49,7 +49,16 @@ class User extends Authenticatable
     // リレーション（多対多）
     public function followers(): BelongsToMany
     {
-        return $this->belongsToMany('App\User', 'follows', 'followee_id', 'follower_id')->withTimeStamps();
+        return $this->belongsToMany('App\User', 'follows', 'followee_id', 'follower_id')->withTimestamps();
+    }
+
+
+    // これからフォローするユーザー、あるいはフォロー中のユーザーのモデルにアクセス可能にするためのリレーションメソッド
+    public function followings(): BelongsToMany
+    {
+        // リレーション元のusersテーブルのidは、中間テーブルのfollower_idと紐付く
+        // リレーション先のusersテーブルのidは、中間テーブルのfollowee_idと紐付く
+        return $this->belongsToMany('App\User', 'follows', 'followee_id', 'follower_id')->withTimestamps();
     }
 
     // あるユーザーをフォロー中かどうかを判定するメソッド

--- a/database/migrations/2020_04_05_170625_create_follows_table.php
+++ b/database/migrations/2020_04_05_170625_create_follows_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('follower_id');
+            $table->foreign('follower_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+            $table->bigInteger('followee_id');
+            $table->foreign('followee_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}

--- a/resources/js/components/FollowButton.vue
+++ b/resources/js/components/FollowButton.vue
@@ -3,6 +3,7 @@
     <button
       class="btn-sm shadow-none border border-primary p-2"
       :class="buttonColor"
+      @click="clickFollow"
     >
       <i
         class="mr-1"
@@ -14,13 +15,27 @@
 </template>
 
 <script>
-  // isFollowedByの状態に応じて、ボタンの色、アイコン、テキストを変える
   export default {
+    props: {
+      initialIsFollowedBy: {
+        type: Boolean,
+        default: false,
+      },
+      authorized: {
+        type: Boolean,
+        default: false,
+      },
+      endpoint: {
+        type: String,
+      },
+    },
     data() {
       return {
-        isFollowedBy: false,
+        // プロパティ initialIsFollowedBy に渡された値をそのまま isFollowedBy にセットする
+        isFollowedBy: this.initialIsFollowedBy,
       }
     },
+    // isFollowedByの状態に応じて、ボタンの色、アイコン、テキストを変える
     computed: {
       buttonColor() {
         return this.isFollowedBy
@@ -38,5 +53,32 @@
           : 'フォロー'
       },
     },
+
+    methods: {
+
+      // クリックされたときに実行
+      clickFollow() {
+        if (!this.authorized) {
+          alert('フォロー機能はログイン中のみ使用できます')
+          return
+        }
+
+        this.isFollowedBy
+          ? this.unfollow()
+          : this.follow()
+      },
+      async follow() {
+        // this.endpoint、つまり users/{name}/followに対してPUTメソッドでリクエスト
+        const response = await axios.put(this.endpoint)
+
+        this.isFollowedBy = true
+      },
+      async unfollow() {
+        // 同上に対してDELETEメソッドでリクエスト
+        const response = await axios.delete(this.endpoint)
+
+        this.isFollowedBy = false
+      },
+    }
   }
 </script>>

--- a/resources/js/components/FollowButton.vue
+++ b/resources/js/components/FollowButton.vue
@@ -79,6 +79,6 @@
 
         this.isFollowedBy = false
       },
-    }
+    },
   }
 </script>>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,10 +19,16 @@
           @if( Auth::id() !== $user->id )
             <follow-button
               class="ml-auto"
+              {{-- @jsonを使うことで $user->isFollowedBy(Auth::user()) の結果を文字列ではなく値で返す --}}
+              :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
+              {{-- フォローはログイン中のみできるため、Authのcheckメソッドでtrueかfalseで返す --}}
+              :authorized='@json(Auth::check())'
+              {{-- route関数で取得したURLを文字列で渡す --}}
+              endpoint="{{ route('users.follow', ['name' => $user->name] )}}"
             >
             </follow-button>
           @endif
-          
+
         </div>
         <h2 class="h5 card-title m-0">
           <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -39,10 +39,10 @@
       <div class="card-body">
         <div class="card-text">
           <a href="" class="text-muted">
-            10 フォロー
+            {{ $user->count_followings }} フォロー
           </a>
           <a href="" class="text-muted">
-            10 フォロー
+            {{ $user->count_followers }}  フォロー
           </a>
         </div>
       </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,4 +19,8 @@ Route::prefix('articles')->name('articles.')->group(function () {
 Route::get('/tags/{name}', 'TagController@show')->name('tags.show');
 Route::prefix('users')->name('users.')->group(function () {
   Route::get('/{name}', 'UserController@show')->name('show');
+  Route::middleware('auth')->group(function () {
+    Route::put('/{name}/follow', 'UserController@follow')->name('follow');
+    Route::delete('/{name}/follow', 'UserController@unfollow')->name('unfollow');
+  });
 });


### PR DESCRIPTION
# フォロー機能の実装

## WHAT

- リレーション元のusersテーブルのidは、中間テーブルのfollower_idと紐付く
- リレーション先のusersテーブルのidは、中間テーブルのfollowee_idと紐付く
- ログインしないとフォロー機能を使うことはできない
- フォロー状態に応じてフォローアイコンが変化
- フォロー中でフォローアイコンをクリックするとフォロー解除
- フォロー数、フォロワー数に応じてユーザーページの数値が変化（これは非同期ではない）
